### PR TITLE
chore: Add 1.0.2 to stable channels

### DIFF
--- a/v4.13/catalog/rhtas-operator/catalog.json
+++ b/v4.13/catalog/rhtas-operator/catalog.json
@@ -5,7 +5,7 @@
 }
 {
     "schema": "olm.channel",
-    "name": "candidate-v1.0",
+    "name": "stable",
     "package": "rhtas-operator",
     "entries": [
         {
@@ -26,20 +26,6 @@
 }
 {
     "schema": "olm.channel",
-    "name": "stable",
-    "package": "rhtas-operator",
-    "entries": [
-        {
-            "name": "rhtas-operator.v1.0.0"
-        },
-        {
-            "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0"
-        }
-    ]
-}
-{
-    "schema": "olm.channel",
     "name": "stable-v1.0",
     "package": "rhtas-operator",
     "entries": [
@@ -49,6 +35,13 @@
         {
             "name": "rhtas-operator.v1.0.1",
             "replaces": "rhtas-operator.v1.0.0"
+        },
+        {
+            "name": "rhtas-operator.v1.0.2",
+            "replaces": "rhtas-operator.v1.0.0",
+            "skips": [
+                "rhtas-operator.v1.0.1"
+            ]
         }
     ]
 }

--- a/v4.13/graph.yaml
+++ b/v4.13/graph.yaml
@@ -10,14 +10,6 @@ entries:
     replaces: rhtas-operator.v1.0.0
     skips:
       - rhtas-operator.v1.0.1
-name: candidate-v1.0
-package: rhtas-operator
-schema: olm.channel
----
-entries:
-  - name: rhtas-operator.v1.0.0
-  - name: rhtas-operator.v1.0.1
-    replaces: rhtas-operator.v1.0.0
 name: stable-v1.0
 package: rhtas-operator
 schema: olm.channel
@@ -26,6 +18,10 @@ entries:
   - name: rhtas-operator.v1.0.0
   - name: rhtas-operator.v1.0.1
     replaces: rhtas-operator.v1.0.0
+  - name: rhtas-operator.v1.0.2
+    replaces: rhtas-operator.v1.0.0
+    skips:
+      - rhtas-operator.v1.0.1
 name: stable
 package: rhtas-operator
 schema: olm.channel

--- a/v4.14/catalog/rhtas-operator/catalog.json
+++ b/v4.14/catalog/rhtas-operator/catalog.json
@@ -5,7 +5,7 @@
 }
 {
     "schema": "olm.channel",
-    "name": "candidate-v1.0",
+    "name": "stable",
     "package": "rhtas-operator",
     "entries": [
         {
@@ -26,20 +26,6 @@
 }
 {
     "schema": "olm.channel",
-    "name": "stable",
-    "package": "rhtas-operator",
-    "entries": [
-        {
-            "name": "rhtas-operator.v1.0.0"
-        },
-        {
-            "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0"
-        }
-    ]
-}
-{
-    "schema": "olm.channel",
     "name": "stable-v1.0",
     "package": "rhtas-operator",
     "entries": [
@@ -49,6 +35,13 @@
         {
             "name": "rhtas-operator.v1.0.1",
             "replaces": "rhtas-operator.v1.0.0"
+        },
+        {
+            "name": "rhtas-operator.v1.0.2",
+            "replaces": "rhtas-operator.v1.0.0",
+            "skips": [
+                "rhtas-operator.v1.0.1"
+            ]
         }
     ]
 }

--- a/v4.14/graph.yaml
+++ b/v4.14/graph.yaml
@@ -10,14 +10,6 @@ entries:
     replaces: rhtas-operator.v1.0.0
     skips:
       - rhtas-operator.v1.0.1
-name: candidate-v1.0
-package: rhtas-operator
-schema: olm.channel
----
-entries:
-  - name: rhtas-operator.v1.0.0
-  - name: rhtas-operator.v1.0.1
-    replaces: rhtas-operator.v1.0.0
 name: stable-v1.0
 package: rhtas-operator
 schema: olm.channel
@@ -26,6 +18,10 @@ entries:
   - name: rhtas-operator.v1.0.0
   - name: rhtas-operator.v1.0.1
     replaces: rhtas-operator.v1.0.0
+  - name: rhtas-operator.v1.0.2
+    replaces: rhtas-operator.v1.0.0
+    skips:
+      - rhtas-operator.v1.0.1
 name: stable
 package: rhtas-operator
 schema: olm.channel

--- a/v4.15/catalog/rhtas-operator/catalog.json
+++ b/v4.15/catalog/rhtas-operator/catalog.json
@@ -5,7 +5,7 @@
 }
 {
     "schema": "olm.channel",
-    "name": "candidate-v1.0",
+    "name": "stable",
     "package": "rhtas-operator",
     "entries": [
         {
@@ -26,20 +26,6 @@
 }
 {
     "schema": "olm.channel",
-    "name": "stable",
-    "package": "rhtas-operator",
-    "entries": [
-        {
-            "name": "rhtas-operator.v1.0.0"
-        },
-        {
-            "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0"
-        }
-    ]
-}
-{
-    "schema": "olm.channel",
     "name": "stable-v1.0",
     "package": "rhtas-operator",
     "entries": [
@@ -49,6 +35,13 @@
         {
             "name": "rhtas-operator.v1.0.1",
             "replaces": "rhtas-operator.v1.0.0"
+        },
+        {
+            "name": "rhtas-operator.v1.0.2",
+            "replaces": "rhtas-operator.v1.0.0",
+            "skips": [
+                "rhtas-operator.v1.0.1"
+            ]
         }
     ]
 }

--- a/v4.15/graph.yaml
+++ b/v4.15/graph.yaml
@@ -10,14 +10,6 @@ entries:
     replaces: rhtas-operator.v1.0.0
     skips:
       - rhtas-operator.v1.0.1
-name: candidate-v1.0
-package: rhtas-operator
-schema: olm.channel
----
-entries:
-  - name: rhtas-operator.v1.0.0
-  - name: rhtas-operator.v1.0.1
-    replaces: rhtas-operator.v1.0.0
 name: stable-v1.0
 package: rhtas-operator
 schema: olm.channel
@@ -26,6 +18,10 @@ entries:
   - name: rhtas-operator.v1.0.0
   - name: rhtas-operator.v1.0.1
     replaces: rhtas-operator.v1.0.0
+  - name: rhtas-operator.v1.0.2
+    replaces: rhtas-operator.v1.0.0
+    skips:
+      - rhtas-operator.v1.0.1
 name: stable
 package: rhtas-operator
 schema: olm.channel

--- a/v4.16/catalog/rhtas-operator/catalog.json
+++ b/v4.16/catalog/rhtas-operator/catalog.json
@@ -5,7 +5,7 @@
 }
 {
     "schema": "olm.channel",
-    "name": "candidate-v1.0",
+    "name": "stable",
     "package": "rhtas-operator",
     "entries": [
         {
@@ -26,20 +26,6 @@
 }
 {
     "schema": "olm.channel",
-    "name": "stable",
-    "package": "rhtas-operator",
-    "entries": [
-        {
-            "name": "rhtas-operator.v1.0.0"
-        },
-        {
-            "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0"
-        }
-    ]
-}
-{
-    "schema": "olm.channel",
     "name": "stable-v1.0",
     "package": "rhtas-operator",
     "entries": [
@@ -49,6 +35,13 @@
         {
             "name": "rhtas-operator.v1.0.1",
             "replaces": "rhtas-operator.v1.0.0"
+        },
+        {
+            "name": "rhtas-operator.v1.0.2",
+            "replaces": "rhtas-operator.v1.0.0",
+            "skips": [
+                "rhtas-operator.v1.0.1"
+            ]
         }
     ]
 }

--- a/v4.16/graph.yaml
+++ b/v4.16/graph.yaml
@@ -10,14 +10,6 @@ entries:
     replaces: rhtas-operator.v1.0.0
     skips:
       - rhtas-operator.v1.0.1
-name: candidate-v1.0
-package: rhtas-operator
-schema: olm.channel
----
-entries:
-  - name: rhtas-operator.v1.0.0
-  - name: rhtas-operator.v1.0.1
-    replaces: rhtas-operator.v1.0.0
 name: stable-v1.0
 package: rhtas-operator
 schema: olm.channel
@@ -26,6 +18,10 @@ entries:
   - name: rhtas-operator.v1.0.0
   - name: rhtas-operator.v1.0.1
     replaces: rhtas-operator.v1.0.0
+  - name: rhtas-operator.v1.0.2
+    replaces: rhtas-operator.v1.0.0
+    skips:
+      - rhtas-operator.v1.0.1
 name: stable
 package: rhtas-operator
 schema: olm.channel

--- a/v4.17/catalog/rhtas-operator/catalog.json
+++ b/v4.17/catalog/rhtas-operator/catalog.json
@@ -5,7 +5,7 @@
 }
 {
     "schema": "olm.channel",
-    "name": "candidate-v1.0",
+    "name": "stable",
     "package": "rhtas-operator",
     "entries": [
         {
@@ -26,20 +26,6 @@
 }
 {
     "schema": "olm.channel",
-    "name": "stable",
-    "package": "rhtas-operator",
-    "entries": [
-        {
-            "name": "rhtas-operator.v1.0.0"
-        },
-        {
-            "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0"
-        }
-    ]
-}
-{
-    "schema": "olm.channel",
     "name": "stable-v1.0",
     "package": "rhtas-operator",
     "entries": [
@@ -49,6 +35,13 @@
         {
             "name": "rhtas-operator.v1.0.1",
             "replaces": "rhtas-operator.v1.0.0"
+        },
+        {
+            "name": "rhtas-operator.v1.0.2",
+            "replaces": "rhtas-operator.v1.0.0",
+            "skips": [
+                "rhtas-operator.v1.0.1"
+            ]
         }
     ]
 }

--- a/v4.17/graph.yaml
+++ b/v4.17/graph.yaml
@@ -10,14 +10,6 @@ entries:
     replaces: rhtas-operator.v1.0.0
     skips:
       - rhtas-operator.v1.0.1
-name: candidate-v1.0
-package: rhtas-operator
-schema: olm.channel
----
-entries:
-  - name: rhtas-operator.v1.0.0
-  - name: rhtas-operator.v1.0.1
-    replaces: rhtas-operator.v1.0.0
 name: stable-v1.0
 package: rhtas-operator
 schema: olm.channel
@@ -26,6 +18,10 @@ entries:
   - name: rhtas-operator.v1.0.0
   - name: rhtas-operator.v1.0.1
     replaces: rhtas-operator.v1.0.0
+  - name: rhtas-operator.v1.0.2
+    replaces: rhtas-operator.v1.0.0
+    skips:
+      - rhtas-operator.v1.0.1
 name: stable
 package: rhtas-operator
 schema: olm.channel


### PR DESCRIPTION
@lance I have prepared this pr to move the 1.0.2 release to the stable channels, I am unsure if we should remove the candidate channel now since it is no longer needed or should we keep it for future use, WDYT?