### PR TITLE
add deprication warning for operator version 1.0.0 

### DIFF
--- a/v4.13/catalog/rhtas-operator/catalog.json
+++ b/v4.13/catalog/rhtas-operator/catalog.json
@@ -9,18 +9,21 @@
     "package": "rhtas-operator",
     "entries": [
         {
-            "name": "rhtas-operator.v1.0.0"
+            "name": "rhtas-operator.v1.0.0",
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0"
+            "replaces": "rhtas-operator.v1.0.0",
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.0.2",
             "replaces": "rhtas-operator.v1.0.0",
             "skips": [
                 "rhtas-operator.v1.0.1"
-            ]
+            ],
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.1.0",
@@ -28,7 +31,8 @@
             "skips": [
                 "rhtas-operator.v1.0.1",
                 "rhtas-operator.v1.0.2"
-            ]
+            ],
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         }
     ]
 }
@@ -38,18 +42,21 @@
     "package": "rhtas-operator",
     "entries": [
         {
-            "name": "rhtas-operator.v1.0.0"
+            "name": "rhtas-operator.v1.0.0",
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0"
+            "replaces": "rhtas-operator.v1.0.0",
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.0.2",
             "replaces": "rhtas-operator.v1.0.0",
             "skips": [
                 "rhtas-operator.v1.0.1"
-            ]
+            ],
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         }
     ]
 }

--- a/v4.13/catalog/rhtas-operator/catalog.json
+++ b/v4.13/catalog/rhtas-operator/catalog.json
@@ -9,21 +9,18 @@
     "package": "rhtas-operator",
     "entries": [
         {
-            "name": "rhtas-operator.v1.0.0",
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            "name": "rhtas-operator.v1.0.0"
         },
         {
             "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0",
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            "replaces": "rhtas-operator.v1.0.0"
         },
         {
             "name": "rhtas-operator.v1.0.2",
             "replaces": "rhtas-operator.v1.0.0",
             "skips": [
                 "rhtas-operator.v1.0.1"
-            ],
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            ]
         },
         {
             "name": "rhtas-operator.v1.1.0",
@@ -31,8 +28,7 @@
             "skips": [
                 "rhtas-operator.v1.0.1",
                 "rhtas-operator.v1.0.2"
-            ],
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            ]
         }
     ]
 }
@@ -42,21 +38,18 @@
     "package": "rhtas-operator",
     "entries": [
         {
-            "name": "rhtas-operator.v1.0.0",
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            "name": "rhtas-operator.v1.0.0"
         },
         {
             "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0",
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            "replaces": "rhtas-operator.v1.0.0"
         },
         {
             "name": "rhtas-operator.v1.0.2",
             "replaces": "rhtas-operator.v1.0.0",
             "skips": [
                 "rhtas-operator.v1.0.1"
-            ],
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            ]
         }
     ]
 }
@@ -842,4 +835,38 @@
             "image": "registry.redhat.io/rhtas/tuffer-rhel9@sha256:79340be7918034c68a334a210ab872161827c99c2a1551a4fce8d5d27560a234"
         }
     ]
+}
+{
+    "entries": [
+        {
+            "message": "channel stable-v1.0 is no longer supported.  Please switch to channel 'stable' or channel 'stable-v1.1'.",
+            "reference": {
+                "name": "stable-v1.0",
+                "schema": "olm.channel"
+            }
+        },
+        {
+            "message": "rhtas-operator.v1.0.0 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.",
+            "reference": {
+                "name": "rhtas-operator.v1.0.0",
+                "schema": "olm.bundle"
+            }
+        },
+        {
+            "message": "rhtas-operator.v1.0.1 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.",
+            "reference": {
+                "name": "rhtas-operator.v1.0.1",
+                "schema": "olm.bundle"
+            }
+        },
+        {
+            "message": "rhtas-operator.v1.0.2 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.",
+            "reference": {
+                "name": "rhtas-operator.v1.0.2",
+                "schema": "olm.bundle"
+            }
+        }
+    ],
+    "package": "rhtas-operator",
+    "schema": "olm.deprecations"
 }

--- a/v4.13/graph.yaml
+++ b/v4.13/graph.yaml
@@ -57,3 +57,23 @@ schema: olm.bundle
 image: registry.redhat.io/rhtas/rhtas-operator-bundle@sha256:d423c8f491a008886926520e12fdd86a5878ce6b5b169100ba495689cff42f2c
 # rhtas-bundle-registry v1.1.0
 ---
+schema: olm.deprecations
+package: rhtas-operator
+entries:
+  - reference:
+      schema: olm.channel
+      name: stable-v1.0
+    message: channel stable-v1.0 is no longer supported.  Please switch to channel 'stable' or channel 'stable-v1.1'.
+  - reference:
+      schema: olm.bundle
+      name: rhtas-operator.v1.0.0
+    message: rhtas-operator.v1.0.0 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+  - reference:
+      schema: olm.bundle
+      name: rhtas-operator.v1.0.1
+    message: rhtas-operator.v1.0.1 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+  - reference:
+      schema: olm.bundle
+      name: rhtas-operator.v1.0.2
+    message: rhtas-operator.v1.0.2 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+---

--- a/v4.13/graph.yaml
+++ b/v4.13/graph.yaml
@@ -67,13 +67,13 @@ entries:
   - reference:
       schema: olm.bundle
       name: rhtas-operator.v1.0.0
-    message: rhtas-operator.v1.0.0 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+    message: rhtas-operator.v1.0.0 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.
   - reference:
       schema: olm.bundle
       name: rhtas-operator.v1.0.1
-    message: rhtas-operator.v1.0.1 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+    message: rhtas-operator.v1.0.1 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.
   - reference:
       schema: olm.bundle
       name: rhtas-operator.v1.0.2
-    message: rhtas-operator.v1.0.2 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+    message: rhtas-operator.v1.0.2 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.
 ---

--- a/v4.14/catalog/rhtas-operator/catalog.json
+++ b/v4.14/catalog/rhtas-operator/catalog.json
@@ -9,18 +9,21 @@
     "package": "rhtas-operator",
     "entries": [
         {
-            "name": "rhtas-operator.v1.0.0"
+            "name": "rhtas-operator.v1.0.0",
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0"
+            "replaces": "rhtas-operator.v1.0.0",
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.0.2",
             "replaces": "rhtas-operator.v1.0.0",
             "skips": [
                 "rhtas-operator.v1.0.1"
-            ]
+            ],
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.1.0",
@@ -28,7 +31,8 @@
             "skips": [
                 "rhtas-operator.v1.0.1",
                 "rhtas-operator.v1.0.2"
-            ]
+            ],
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         }
     ]
 }
@@ -38,18 +42,21 @@
     "package": "rhtas-operator",
     "entries": [
         {
-            "name": "rhtas-operator.v1.0.0"
+            "name": "rhtas-operator.v1.0.0",
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0"
+            "replaces": "rhtas-operator.v1.0.0",
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.0.2",
             "replaces": "rhtas-operator.v1.0.0",
             "skips": [
                 "rhtas-operator.v1.0.1"
-            ]
+            ],
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         }
     ]
 }

--- a/v4.14/catalog/rhtas-operator/catalog.json
+++ b/v4.14/catalog/rhtas-operator/catalog.json
@@ -9,21 +9,18 @@
     "package": "rhtas-operator",
     "entries": [
         {
-            "name": "rhtas-operator.v1.0.0",
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            "name": "rhtas-operator.v1.0.0"
         },
         {
             "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0",
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            "replaces": "rhtas-operator.v1.0.0"
         },
         {
             "name": "rhtas-operator.v1.0.2",
             "replaces": "rhtas-operator.v1.0.0",
             "skips": [
                 "rhtas-operator.v1.0.1"
-            ],
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            ]
         },
         {
             "name": "rhtas-operator.v1.1.0",
@@ -31,8 +28,7 @@
             "skips": [
                 "rhtas-operator.v1.0.1",
                 "rhtas-operator.v1.0.2"
-            ],
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            ]
         }
     ]
 }
@@ -42,21 +38,18 @@
     "package": "rhtas-operator",
     "entries": [
         {
-            "name": "rhtas-operator.v1.0.0",
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            "name": "rhtas-operator.v1.0.0"
         },
         {
             "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0",
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            "replaces": "rhtas-operator.v1.0.0"
         },
         {
             "name": "rhtas-operator.v1.0.2",
             "replaces": "rhtas-operator.v1.0.0",
             "skips": [
                 "rhtas-operator.v1.0.1"
-            ],
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            ]
         }
     ]
 }
@@ -842,4 +835,38 @@
             "image": "registry.redhat.io/rhtas/tuffer-rhel9@sha256:79340be7918034c68a334a210ab872161827c99c2a1551a4fce8d5d27560a234"
         }
     ]
+}
+{
+    "entries": [
+        {
+            "message": "channel stable-v1.0 is no longer supported.  Please switch to channel 'stable' or channel 'stable-v1.1'.",
+            "reference": {
+                "name": "stable-v1.0",
+                "schema": "olm.channel"
+            }
+        },
+        {
+            "message": "rhtas-operator.v1.0.0 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.",
+            "reference": {
+                "name": "rhtas-operator.v1.0.0",
+                "schema": "olm.bundle"
+            }
+        },
+        {
+            "message": "rhtas-operator.v1.0.1 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.",
+            "reference": {
+                "name": "rhtas-operator.v1.0.1",
+                "schema": "olm.bundle"
+            }
+        },
+        {
+            "message": "rhtas-operator.v1.0.2 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.",
+            "reference": {
+                "name": "rhtas-operator.v1.0.2",
+                "schema": "olm.bundle"
+            }
+        }
+    ],
+    "package": "rhtas-operator",
+    "schema": "olm.deprecations"
 }

--- a/v4.14/graph.yaml
+++ b/v4.14/graph.yaml
@@ -57,3 +57,23 @@ schema: olm.bundle
 image: registry.redhat.io/rhtas/rhtas-operator-bundle@sha256:d423c8f491a008886926520e12fdd86a5878ce6b5b169100ba495689cff42f2c
 # rhtas-bundle-registry v1.1.0
 ---
+schema: olm.deprecations
+package: rhtas-operator
+entries:
+  - reference:
+      schema: olm.channel
+      name: stable-v1.0
+    message: channel stable-v1.0 is no longer supported.  Please switch to channel 'stable' or channel 'stable-v1.1'.
+  - reference:
+      schema: olm.bundle
+      name: rhtas-operator.v1.0.0
+    message: rhtas-operator.v1.0.0 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+  - reference:
+      schema: olm.bundle
+      name: rhtas-operator.v1.0.1
+    message: rhtas-operator.v1.0.1 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+  - reference:
+      schema: olm.bundle
+      name: rhtas-operator.v1.0.2
+    message: rhtas-operator.v1.0.2 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+---

--- a/v4.14/graph.yaml
+++ b/v4.14/graph.yaml
@@ -67,13 +67,13 @@ entries:
   - reference:
       schema: olm.bundle
       name: rhtas-operator.v1.0.0
-    message: rhtas-operator.v1.0.0 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+    message: rhtas-operator.v1.0.0 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.
   - reference:
       schema: olm.bundle
       name: rhtas-operator.v1.0.1
-    message: rhtas-operator.v1.0.1 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+    message: rhtas-operator.v1.0.1 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.
   - reference:
       schema: olm.bundle
       name: rhtas-operator.v1.0.2
-    message: rhtas-operator.v1.0.2 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+    message: rhtas-operator.v1.0.2 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.
 ---

--- a/v4.15/catalog/rhtas-operator/catalog.json
+++ b/v4.15/catalog/rhtas-operator/catalog.json
@@ -9,18 +9,21 @@
     "package": "rhtas-operator",
     "entries": [
         {
-            "name": "rhtas-operator.v1.0.0"
+            "name": "rhtas-operator.v1.0.0",
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0"
+            "replaces": "rhtas-operator.v1.0.0",
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.0.2",
             "replaces": "rhtas-operator.v1.0.0",
             "skips": [
                 "rhtas-operator.v1.0.1"
-            ]
+            ],
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.1.0",
@@ -28,7 +31,8 @@
             "skips": [
                 "rhtas-operator.v1.0.1",
                 "rhtas-operator.v1.0.2"
-            ]
+            ],
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         }
     ]
 }
@@ -38,18 +42,21 @@
     "package": "rhtas-operator",
     "entries": [
         {
-            "name": "rhtas-operator.v1.0.0"
+            "name": "rhtas-operator.v1.0.0",
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0"
+            "replaces": "rhtas-operator.v1.0.0",
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.0.2",
             "replaces": "rhtas-operator.v1.0.0",
             "skips": [
                 "rhtas-operator.v1.0.1"
-            ]
+            ],
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         }
     ]
 }

--- a/v4.15/catalog/rhtas-operator/catalog.json
+++ b/v4.15/catalog/rhtas-operator/catalog.json
@@ -9,21 +9,18 @@
     "package": "rhtas-operator",
     "entries": [
         {
-            "name": "rhtas-operator.v1.0.0",
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            "name": "rhtas-operator.v1.0.0"
         },
         {
             "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0",
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            "replaces": "rhtas-operator.v1.0.0"
         },
         {
             "name": "rhtas-operator.v1.0.2",
             "replaces": "rhtas-operator.v1.0.0",
             "skips": [
                 "rhtas-operator.v1.0.1"
-            ],
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            ]
         },
         {
             "name": "rhtas-operator.v1.1.0",
@@ -31,8 +28,7 @@
             "skips": [
                 "rhtas-operator.v1.0.1",
                 "rhtas-operator.v1.0.2"
-            ],
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            ]
         }
     ]
 }
@@ -42,21 +38,18 @@
     "package": "rhtas-operator",
     "entries": [
         {
-            "name": "rhtas-operator.v1.0.0",
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            "name": "rhtas-operator.v1.0.0"
         },
         {
             "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0",
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            "replaces": "rhtas-operator.v1.0.0"
         },
         {
             "name": "rhtas-operator.v1.0.2",
             "replaces": "rhtas-operator.v1.0.0",
             "skips": [
                 "rhtas-operator.v1.0.1"
-            ],
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            ]
         }
     ]
 }
@@ -842,4 +835,38 @@
             "image": "registry.redhat.io/rhtas/tuffer-rhel9@sha256:79340be7918034c68a334a210ab872161827c99c2a1551a4fce8d5d27560a234"
         }
     ]
+}
+{
+    "entries": [
+        {
+            "message": "channel stable-v1.0 is no longer supported.  Please switch to channel 'stable' or channel 'stable-v1.1'.",
+            "reference": {
+                "name": "stable-v1.0",
+                "schema": "olm.channel"
+            }
+        },
+        {
+            "message": "rhtas-operator.v1.0.0 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.",
+            "reference": {
+                "name": "rhtas-operator.v1.0.0",
+                "schema": "olm.bundle"
+            }
+        },
+        {
+            "message": "rhtas-operator.v1.0.1 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.",
+            "reference": {
+                "name": "rhtas-operator.v1.0.1",
+                "schema": "olm.bundle"
+            }
+        },
+        {
+            "message": "rhtas-operator.v1.0.2 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.",
+            "reference": {
+                "name": "rhtas-operator.v1.0.2",
+                "schema": "olm.bundle"
+            }
+        }
+    ],
+    "package": "rhtas-operator",
+    "schema": "olm.deprecations"
 }

--- a/v4.15/graph.yaml
+++ b/v4.15/graph.yaml
@@ -57,3 +57,23 @@ schema: olm.bundle
 image: registry.redhat.io/rhtas/rhtas-operator-bundle@sha256:d423c8f491a008886926520e12fdd86a5878ce6b5b169100ba495689cff42f2c
 # rhtas-bundle-registry v1.1.0
 ---
+schema: olm.deprecations
+package: rhtas-operator
+entries:
+  - reference:
+      schema: olm.channel
+      name: stable-v1.0
+    message: channel stable-v1.0 is no longer supported.  Please switch to channel 'stable' or channel 'stable-v1.1'.
+  - reference:
+      schema: olm.bundle
+      name: rhtas-operator.v1.0.0
+    message: rhtas-operator.v1.0.0 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+  - reference:
+      schema: olm.bundle
+      name: rhtas-operator.v1.0.1
+    message: rhtas-operator.v1.0.1 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+  - reference:
+      schema: olm.bundle
+      name: rhtas-operator.v1.0.2
+    message: rhtas-operator.v1.0.2 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+---

--- a/v4.15/graph.yaml
+++ b/v4.15/graph.yaml
@@ -67,13 +67,13 @@ entries:
   - reference:
       schema: olm.bundle
       name: rhtas-operator.v1.0.0
-    message: rhtas-operator.v1.0.0 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+    message: rhtas-operator.v1.0.0 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.
   - reference:
       schema: olm.bundle
       name: rhtas-operator.v1.0.1
-    message: rhtas-operator.v1.0.1 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+    message: rhtas-operator.v1.0.1 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.
   - reference:
       schema: olm.bundle
       name: rhtas-operator.v1.0.2
-    message: rhtas-operator.v1.0.2 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+    message: rhtas-operator.v1.0.2 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.
 ---

--- a/v4.16/catalog/rhtas-operator/catalog.json
+++ b/v4.16/catalog/rhtas-operator/catalog.json
@@ -9,18 +9,21 @@
     "package": "rhtas-operator",
     "entries": [
         {
-            "name": "rhtas-operator.v1.0.0"
+            "name": "rhtas-operator.v1.0.0",
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0"
+            "replaces": "rhtas-operator.v1.0.0",
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.0.2",
             "replaces": "rhtas-operator.v1.0.0",
             "skips": [
                 "rhtas-operator.v1.0.1"
-            ]
+            ],
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.1.0",
@@ -28,7 +31,8 @@
             "skips": [
                 "rhtas-operator.v1.0.1",
                 "rhtas-operator.v1.0.2"
-            ]
+            ],
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         }
     ]
 }
@@ -38,18 +42,21 @@
     "package": "rhtas-operator",
     "entries": [
         {
-            "name": "rhtas-operator.v1.0.0"
+            "name": "rhtas-operator.v1.0.0",
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0"
+            "replaces": "rhtas-operator.v1.0.0",
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.0.2",
             "replaces": "rhtas-operator.v1.0.0",
             "skips": [
                 "rhtas-operator.v1.0.1"
-            ]
+            ],
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         }
     ]
 }

--- a/v4.16/catalog/rhtas-operator/catalog.json
+++ b/v4.16/catalog/rhtas-operator/catalog.json
@@ -9,21 +9,18 @@
     "package": "rhtas-operator",
     "entries": [
         {
-            "name": "rhtas-operator.v1.0.0",
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            "name": "rhtas-operator.v1.0.0"
         },
         {
             "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0",
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            "replaces": "rhtas-operator.v1.0.0"
         },
         {
             "name": "rhtas-operator.v1.0.2",
             "replaces": "rhtas-operator.v1.0.0",
             "skips": [
                 "rhtas-operator.v1.0.1"
-            ],
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            ]
         },
         {
             "name": "rhtas-operator.v1.1.0",
@@ -31,8 +28,7 @@
             "skips": [
                 "rhtas-operator.v1.0.1",
                 "rhtas-operator.v1.0.2"
-            ],
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            ]
         }
     ]
 }
@@ -42,21 +38,18 @@
     "package": "rhtas-operator",
     "entries": [
         {
-            "name": "rhtas-operator.v1.0.0",
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            "name": "rhtas-operator.v1.0.0"
         },
         {
             "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0",
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            "replaces": "rhtas-operator.v1.0.0"
         },
         {
             "name": "rhtas-operator.v1.0.2",
             "replaces": "rhtas-operator.v1.0.0",
             "skips": [
                 "rhtas-operator.v1.0.1"
-            ],
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            ]
         }
     ]
 }
@@ -842,4 +835,38 @@
             "image": "registry.redhat.io/rhtas/tuffer-rhel9@sha256:79340be7918034c68a334a210ab872161827c99c2a1551a4fce8d5d27560a234"
         }
     ]
+}
+{
+    "entries": [
+        {
+            "message": "channel stable-v1.0 is no longer supported.  Please switch to channel 'stable' or channel 'stable-v1.1'.",
+            "reference": {
+                "name": "stable-v1.0",
+                "schema": "olm.channel"
+            }
+        },
+        {
+            "message": "rhtas-operator.v1.0.0 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.",
+            "reference": {
+                "name": "rhtas-operator.v1.0.0",
+                "schema": "olm.bundle"
+            }
+        },
+        {
+            "message": "rhtas-operator.v1.0.1 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.",
+            "reference": {
+                "name": "rhtas-operator.v1.0.1",
+                "schema": "olm.bundle"
+            }
+        },
+        {
+            "message": "rhtas-operator.v1.0.2 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.",
+            "reference": {
+                "name": "rhtas-operator.v1.0.2",
+                "schema": "olm.bundle"
+            }
+        }
+    ],
+    "package": "rhtas-operator",
+    "schema": "olm.deprecations"
 }

--- a/v4.16/graph.yaml
+++ b/v4.16/graph.yaml
@@ -57,3 +57,23 @@ schema: olm.bundle
 image: registry.redhat.io/rhtas/rhtas-operator-bundle@sha256:d423c8f491a008886926520e12fdd86a5878ce6b5b169100ba495689cff42f2c
 # rhtas-bundle-registry v1.1.0
 ---
+schema: olm.deprecations
+package: rhtas-operator
+entries:
+  - reference:
+      schema: olm.channel
+      name: stable-v1.0
+    message: channel stable-v1.0 is no longer supported.  Please switch to channel 'stable' or channel 'stable-v1.1'.
+  - reference:
+      schema: olm.bundle
+      name: rhtas-operator.v1.0.0
+    message: rhtas-operator.v1.0.0 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+  - reference:
+      schema: olm.bundle
+      name: rhtas-operator.v1.0.1
+    message: rhtas-operator.v1.0.1 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+  - reference:
+      schema: olm.bundle
+      name: rhtas-operator.v1.0.2
+    message: rhtas-operator.v1.0.2 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+---

--- a/v4.16/graph.yaml
+++ b/v4.16/graph.yaml
@@ -67,13 +67,13 @@ entries:
   - reference:
       schema: olm.bundle
       name: rhtas-operator.v1.0.0
-    message: rhtas-operator.v1.0.0 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+    message: rhtas-operator.v1.0.0 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.
   - reference:
       schema: olm.bundle
       name: rhtas-operator.v1.0.1
-    message: rhtas-operator.v1.0.1 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+    message: rhtas-operator.v1.0.1 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.
   - reference:
       schema: olm.bundle
       name: rhtas-operator.v1.0.2
-    message: rhtas-operator.v1.0.2 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+    message: rhtas-operator.v1.0.2 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.
 ---

--- a/v4.17/catalog/rhtas-operator/catalog.json
+++ b/v4.17/catalog/rhtas-operator/catalog.json
@@ -9,21 +9,18 @@
     "package": "rhtas-operator",
     "entries": [
         {
-            "name": "rhtas-operator.v1.0.0",
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            "name": "rhtas-operator.v1.0.0"
         },
         {
             "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0",
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            "replaces": "rhtas-operator.v1.0.0"
         },
         {
             "name": "rhtas-operator.v1.0.2",
             "replaces": "rhtas-operator.v1.0.0",
             "skips": [
                 "rhtas-operator.v1.0.1"
-            ],
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            ]
         },
         {
             "name": "rhtas-operator.v1.1.0",
@@ -31,8 +28,7 @@
             "skips": [
                 "rhtas-operator.v1.0.1",
                 "rhtas-operator.v1.0.2"
-            ],
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            ]
         }
     ]
 }
@@ -42,21 +38,18 @@
     "package": "rhtas-operator",
     "entries": [
         {
-            "name": "rhtas-operator.v1.0.0",
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            "name": "rhtas-operator.v1.0.0"
         },
         {
             "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0",
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            "replaces": "rhtas-operator.v1.0.0"
         },
         {
             "name": "rhtas-operator.v1.0.2",
             "replaces": "rhtas-operator.v1.0.0",
             "skips": [
                 "rhtas-operator.v1.0.1"
-            ],
-            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
+            ]
         }
     ]
 }
@@ -1202,4 +1195,38 @@
             "image": "registry.redhat.io/rhtas/tuffer-rhel9@sha256:79340be7918034c68a334a210ab872161827c99c2a1551a4fce8d5d27560a234"
         }
     ]
+}
+{
+    "entries": [
+        {
+            "message": "channel stable-v1.0 is no longer supported.  Please switch to channel 'stable' or channel 'stable-v1.1'.",
+            "reference": {
+                "name": "stable-v1.0",
+                "schema": "olm.channel"
+            }
+        },
+        {
+            "message": "rhtas-operator.v1.0.0 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.",
+            "reference": {
+                "name": "rhtas-operator.v1.0.0",
+                "schema": "olm.bundle"
+            }
+        },
+        {
+            "message": "rhtas-operator.v1.0.1 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.",
+            "reference": {
+                "name": "rhtas-operator.v1.0.1",
+                "schema": "olm.bundle"
+            }
+        },
+        {
+            "message": "rhtas-operator.v1.0.2 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.",
+            "reference": {
+                "name": "rhtas-operator.v1.0.2",
+                "schema": "olm.bundle"
+            }
+        }
+    ],
+    "package": "rhtas-operator",
+    "schema": "olm.deprecations"
 }

--- a/v4.17/catalog/rhtas-operator/catalog.json
+++ b/v4.17/catalog/rhtas-operator/catalog.json
@@ -9,18 +9,21 @@
     "package": "rhtas-operator",
     "entries": [
         {
-            "name": "rhtas-operator.v1.0.0"
+            "name": "rhtas-operator.v1.0.0",
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0"
+            "replaces": "rhtas-operator.v1.0.0",
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.0.2",
             "replaces": "rhtas-operator.v1.0.0",
             "skips": [
                 "rhtas-operator.v1.0.1"
-            ]
+            ],
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.1.0",
@@ -28,7 +31,8 @@
             "skips": [
                 "rhtas-operator.v1.0.1",
                 "rhtas-operator.v1.0.2"
-            ]
+            ],
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         }
     ]
 }
@@ -38,18 +42,21 @@
     "package": "rhtas-operator",
     "entries": [
         {
-            "name": "rhtas-operator.v1.0.0"
+            "name": "rhtas-operator.v1.0.0",
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.0.1",
-            "replaces": "rhtas-operator.v1.0.0"
+            "replaces": "rhtas-operator.v1.0.0",
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         },
         {
             "name": "rhtas-operator.v1.0.2",
             "replaces": "rhtas-operator.v1.0.0",
             "skips": [
                 "rhtas-operator.v1.0.1"
-            ]
+            ],
+            "message": "This version is deprecated. Please upgrade to rhtas-operator.v1.1.0."
         }
     ]
 }

--- a/v4.17/graph.yaml
+++ b/v4.17/graph.yaml
@@ -57,3 +57,23 @@ schema: olm.bundle
 image: registry.redhat.io/rhtas/rhtas-operator-bundle@sha256:d423c8f491a008886926520e12fdd86a5878ce6b5b169100ba495689cff42f2c
 # rhtas-bundle-registry v1.1.0
 ---
+schema: olm.deprecations
+package: rhtas-operator
+entries:
+  - reference:
+      schema: olm.channel
+      name: stable-v1.0
+    message: channel stable-v1.0 is no longer supported.  Please switch to channel 'stable' or channel 'stable-v1.1'.
+  - reference:
+      schema: olm.bundle
+      name: rhtas-operator.v1.0.0
+    message: rhtas-operator.v1.0.0 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+  - reference:
+      schema: olm.bundle
+      name: rhtas-operator.v1.0.1
+    message: rhtas-operator.v1.0.1 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+  - reference:
+      schema: olm.bundle
+      name: rhtas-operator.v1.0.2
+    message: rhtas-operator.v1.0.2 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+---

--- a/v4.17/graph.yaml
+++ b/v4.17/graph.yaml
@@ -67,13 +67,13 @@ entries:
   - reference:
       schema: olm.bundle
       name: rhtas-operator.v1.0.0
-    message: rhtas-operator.v1.0.0 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+    message: rhtas-operator.v1.0.0 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.
   - reference:
       schema: olm.bundle
       name: rhtas-operator.v1.0.1
-    message: rhtas-operator.v1.0.1 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+    message: rhtas-operator.v1.0.1 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.
   - reference:
       schema: olm.bundle
       name: rhtas-operator.v1.0.2
-    message: rhtas-operator.v1.0.2 is deprecated. Uninstall and install rhtas-operator.v1.1.0 for support.
+    message: rhtas-operator.v1.0.2 is deprecated. Uninstall and install rhtas-operator.v1.1.1 for support.
 ---


### PR DESCRIPTION
**Updated the `operator catalog` with deprecation warnings:**

**Deprecation warning for `operator-v1.0.0`:**
Added a message recommending users to upgrade to `operator-v1.1.0` for continued support.

**Deprecation warning for `stable-v1.0 channel`:**
Added a message recommending users to switch to the newer `stable-v1.1` channel.

I used this [schema](https://olm.operatorframework.io/docs/reference/file-based-catalogs/#olmdeprecations).