### PR TITLE
Adding 1.1.3 channel

### DIFF
--- a/v4.14/graph.yaml
+++ b/v4.14/graph.yaml
@@ -22,6 +22,12 @@ entries:
           - rhtas-operator.v1.0.2
           - rhtas-operator.v1.1.0
           - rhtas-operator.v1.1.1
+      - name: rhtas-operator.v1.1.3
+        replaces: rhtas-operator.v1.1.0
+        skips:
+          - rhtas-operator.v1.1.0
+          - rhtas-operator.v1.1.1
+          - rhtas-operator.v1.1.2
     name: stable-v1.1
     package: rhtas-operator
     schema: olm.channel

--- a/v4.15/graph.yaml
+++ b/v4.15/graph.yaml
@@ -22,6 +22,12 @@ entries:
           - rhtas-operator.v1.0.2
           - rhtas-operator.v1.1.0
           - rhtas-operator.v1.1.1
+      - name: rhtas-operator.v1.1.3
+        replaces: rhtas-operator.v1.1.0
+        skips:
+          - rhtas-operator.v1.1.0
+          - rhtas-operator.v1.1.1
+          - rhtas-operator.v1.1.2
     name: stable-v1.1
     package: rhtas-operator
     schema: olm.channel

--- a/v4.16/graph.yaml
+++ b/v4.16/graph.yaml
@@ -22,6 +22,12 @@ entries:
           - rhtas-operator.v1.0.2
           - rhtas-operator.v1.1.0
           - rhtas-operator.v1.1.1
+      - name: rhtas-operator.v1.1.3
+        replaces: rhtas-operator.v1.1.0
+        skips:
+          - rhtas-operator.v1.1.0
+          - rhtas-operator.v1.1.1
+          - rhtas-operator.v1.1.2
     name: stable-v1.1
     package: rhtas-operator
     schema: olm.channel

--- a/v4.17/graph.yaml
+++ b/v4.17/graph.yaml
@@ -22,6 +22,12 @@ entries:
           - rhtas-operator.v1.0.2
           - rhtas-operator.v1.1.0
           - rhtas-operator.v1.1.1
+      - name: rhtas-operator.v1.1.3
+        replaces: rhtas-operator.v1.1.0
+        skips:
+          - rhtas-operator.v1.1.0
+          - rhtas-operator.v1.1.1
+          - rhtas-operator.v1.1.2
     name: stable-v1.1
     package: rhtas-operator
     schema: olm.channel

--- a/v4.18/graph.yaml
+++ b/v4.18/graph.yaml
@@ -22,6 +22,12 @@ entries:
           - rhtas-operator.v1.0.2
           - rhtas-operator.v1.1.0
           - rhtas-operator.v1.1.1
+      - name: rhtas-operator.v1.1.3
+        replaces: rhtas-operator.v1.1.0
+        skips:
+          - rhtas-operator.v1.1.0
+          - rhtas-operator.v1.1.1
+          - rhtas-operator.v1.1.2
     name: stable-v1.1
     package: rhtas-operator
     schema: olm.channel


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Add rhtas-operator.v1.1.3 entry to stable-v1.1 channel in graph.yaml for versions v4.14 through v4.18, replacing v1.1.0 and skipping v1.1.0–v1.1.2