### PR TITLE
Update utils script

### DIFF
--- a/utils/render_catalog.sh
+++ b/utils/render_catalog.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 # OCP_VERSION="v4.13"
-# CATALOG_FILE="v4.13/catalog/rhtas-operator/catalog.json"
+# FBC_DIR="rhtas-operator"
+# CATALOG_FILE="v4.13/${FBC_DIR}/catalog/rhtas-operator/catalog.json"
 
 minor=${OCP_VERSION#v4.}
 minor=${minor%%.*}
@@ -31,7 +32,7 @@ if (( minor >= 17 )); then
     migrate_flag="--migrate-level=bundle-object-to-csv-metadata"
 fi
 
-opm alpha render-template $migrate_flag basic "${OCP_VERSION}/graph.yaml" > "$CATALOG_FILE"
+opm alpha render-template $migrate_flag basic "${OCP_VERSION}/${FBC_DIR}/graph.yaml" > "$CATALOG_FILE"
 
 jq -s --indent 4 --argjson related_images "$related_images" '
     map(


### PR DESCRIPTION
## Summary by Sourcery

Parameterize the operator subdirectory in render_catalog.sh by introducing a FBC_DIR variable and updating related file paths.

Enhancements:
- Add FBC_DIR variable to specify the operator directory
- Update CATALOG_FILE path to include the FBC_DIR variable
- Adjust opm render-template invocation to reference the FBC_DIR in the graph.yaml path