### PR TITLE
Update Replacement Value for 1.3.0

### DIFF
--- a/v4.14/rhtas-operator/catalog/rhtas-operator/catalog.json
+++ b/v4.14/rhtas-operator/catalog/rhtas-operator/catalog.json
@@ -82,12 +82,6 @@
             "name": "rhtas-operator.v1.3.0",
             "replaces": "rhtas-operator.v1.2.0",
             "skips": [
-                "rhtas-operator.v1.0.0",
-                "rhtas-operator.v1.0.1",
-                "rhtas-operator.v1.0.2",
-                "rhtas-operator.v1.1.0",
-                "rhtas-operator.v1.1.1",
-                "rhtas-operator.v1.1.2",
                 "rhtas-operator.v1.2.0",
                 "rhtas-operator.v1.2.1"
             ]

--- a/v4.14/rhtas-operator/graph.yaml
+++ b/v4.14/rhtas-operator/graph.yaml
@@ -101,7 +101,9 @@ entries:
       - name: rhtas-operator.v1.3.0
         replaces: rhtas-operator.v1.2.0
         skips:
+          - rhtas-operator.v1.2.0
           - rhtas-operator.v1.2.1
+
     name: stable
     package: rhtas-operator
     schema: olm.channel

--- a/v4.15/rhtas-operator/catalog/rhtas-operator/catalog.json
+++ b/v4.15/rhtas-operator/catalog/rhtas-operator/catalog.json
@@ -82,6 +82,7 @@
             "name": "rhtas-operator.v1.3.0",
             "replaces": "rhtas-operator.v1.2.0",
             "skips": [
+                "rhtas-operator.v1.2.0",
                 "rhtas-operator.v1.2.1"
             ]
         }

--- a/v4.15/rhtas-operator/graph.yaml
+++ b/v4.15/rhtas-operator/graph.yaml
@@ -101,7 +101,9 @@ entries:
       - name: rhtas-operator.v1.3.0
         replaces: rhtas-operator.v1.2.0
         skips:
+          - rhtas-operator.v1.2.0
           - rhtas-operator.v1.2.1
+
     name: stable
     package: rhtas-operator
     schema: olm.channel

--- a/v4.16/rhtas-operator/catalog/rhtas-operator/catalog.json
+++ b/v4.16/rhtas-operator/catalog/rhtas-operator/catalog.json
@@ -82,6 +82,7 @@
             "name": "rhtas-operator.v1.3.0",
             "replaces": "rhtas-operator.v1.2.0",
             "skips": [
+                "rhtas-operator.v1.2.0",
                 "rhtas-operator.v1.2.1"
             ]
         }

--- a/v4.16/rhtas-operator/graph.yaml
+++ b/v4.16/rhtas-operator/graph.yaml
@@ -101,7 +101,9 @@ entries:
       - name: rhtas-operator.v1.3.0
         replaces: rhtas-operator.v1.2.0
         skips:
+          - rhtas-operator.v1.2.0
           - rhtas-operator.v1.2.1
+
     name: stable
     package: rhtas-operator
     schema: olm.channel

--- a/v4.17/rhtas-operator/catalog/rhtas-operator/catalog.json
+++ b/v4.17/rhtas-operator/catalog/rhtas-operator/catalog.json
@@ -82,6 +82,7 @@
             "name": "rhtas-operator.v1.3.0",
             "replaces": "rhtas-operator.v1.2.0",
             "skips": [
+                "rhtas-operator.v1.2.0",
                 "rhtas-operator.v1.2.1"
             ]
         }

--- a/v4.17/rhtas-operator/graph.yaml
+++ b/v4.17/rhtas-operator/graph.yaml
@@ -101,7 +101,9 @@ entries:
       - name: rhtas-operator.v1.3.0
         replaces: rhtas-operator.v1.2.0
         skips:
+          - rhtas-operator.v1.2.0
           - rhtas-operator.v1.2.1
+
     name: stable
     package: rhtas-operator
     schema: olm.channel

--- a/v4.18/rhtas-operator/catalog/rhtas-operator/catalog.json
+++ b/v4.18/rhtas-operator/catalog/rhtas-operator/catalog.json
@@ -82,6 +82,7 @@
             "name": "rhtas-operator.v1.3.0",
             "replaces": "rhtas-operator.v1.2.0",
             "skips": [
+                "rhtas-operator.v1.2.0",
                 "rhtas-operator.v1.2.1"
             ]
         }

--- a/v4.18/rhtas-operator/graph.yaml
+++ b/v4.18/rhtas-operator/graph.yaml
@@ -101,7 +101,9 @@ entries:
       - name: rhtas-operator.v1.3.0
         replaces: rhtas-operator.v1.2.0
         skips:
+          - rhtas-operator.v1.2.0
           - rhtas-operator.v1.2.1
+
     name: stable
     package: rhtas-operator
     schema: olm.channel

--- a/v4.19/rhtas-operator/catalog/rhtas-operator/catalog.json
+++ b/v4.19/rhtas-operator/catalog/rhtas-operator/catalog.json
@@ -82,6 +82,7 @@
             "name": "rhtas-operator.v1.3.0",
             "replaces": "rhtas-operator.v1.2.0",
             "skips": [
+                "rhtas-operator.v1.2.0",
                 "rhtas-operator.v1.2.1"
             ]
         }

--- a/v4.19/rhtas-operator/graph.yaml
+++ b/v4.19/rhtas-operator/graph.yaml
@@ -101,7 +101,9 @@ entries:
       - name: rhtas-operator.v1.3.0
         replaces: rhtas-operator.v1.2.0
         skips:
+          - rhtas-operator.v1.2.0
           - rhtas-operator.v1.2.1
+
     name: stable
     package: rhtas-operator
     schema: olm.channel


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Update the "replaces" field for rhtas-operator v1.3.0 to v1.2.0 in graph.yaml for versions 4.14 through 4.19