### PR TITLE
fix: update configure_channels script so that it can handle multiple …

### DIFF
--- a/utils/configure_channels.sh
+++ b/utils/configure_channels.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 #export CHANNELS="stable,stable-v1.2"
 #export GRAPH="v4.19/rhtas-operator/graph.yaml"
 
+# Returns true if version $1 <= version $2
+version_lte() {
+  [[ "$(printf '%s\n%s' "$1" "$2" | sort -V | head -1)" == "$1" ]]
+}
+
 export PACKAGE_NAME=$(yq e '.entries[] | select(.schema=="olm.package") | .name' $GRAPH)
 IFS=',' read -ra channel_list <<< "$CHANNELS"
 for channel in "${channel_list[@]}"; do
@@ -19,11 +24,23 @@ for channel in "${channel_list[@]}"; do
     ENTRIES_WO_BUNDLE=$(echo "$CURRENT_ENTRIES" | grep -v "^${BUNDLE_NAME}$" || true)
     
     if [[ -n "$ENTRIES_WO_BUNDLE" ]]; then
-      export MAJOR_VERSIONS=$(echo $ENTRIES_WO_BUNDLE | tr ' ' '\n' | grep -E '\.0$')
+      # Extract the minor version from the bundle name (e.g., "1.2" from "rhtas-operator.v1.2.1")
+      BUNDLE_MINOR=$(echo "$BUNDLE_NAME" | grep -oE 'v[0-9]+\.[0-9]+' | sed 's/^v//')
+
+      # Filter entries to only include versions in the same or earlier minor series
+      ELIGIBLE_ENTRIES=$(echo "$ENTRIES_WO_BUNDLE" | tr ' ' '\n' | while read -r entry; do
+        ENTRY_MINOR=$(echo "$entry" | grep -oE 'v[0-9]+\.[0-9]+' | sed 's/^v//')
+        if [[ -n "$ENTRY_MINOR" ]] && version_lte "$ENTRY_MINOR" "$BUNDLE_MINOR"; then
+          echo "$entry"
+        fi
+      done)
+
+      export MAJOR_VERSIONS=$(echo "$ELIGIBLE_ENTRIES" | grep -E '\.0$')
       export REPLACES=$(echo "$MAJOR_VERSIONS" | sort -V | tail -n 1)
-      export SKIPS=$(echo "$ENTRIES_WO_BUNDLE" \
-        | grep -v -E '\.v1\.(0|1)\.[0-9]+' \
-        | awk '{print "\"" $0 "\""}' \
+
+      SKIPS_ENTRIES=$(echo "$ELIGIBLE_ENTRIES" | grep -v -E '\.v1\.(0|1)\.[0-9]+')
+      export SKIPS=$(echo "$SKIPS_ENTRIES" \
+        | awk 'NF {print "\"" $0 "\""}' \
         | paste -sd, - \
         | sed 's/^/[/' | sed 's/$/]/'
       )


### PR DESCRIPTION
### **User description**
…streams


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add version comparison function to handle multiple stream versions

- Filter eligible entries by minor version to prevent incompatible replacements

- Improve bundle version extraction and filtering logic

- Fix SKIPS calculation to handle empty results gracefully


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Bundle Version Extraction"] --> B["Minor Version Comparison"]
  B --> C["Filter Eligible Entries"]
  C --> D["Calculate REPLACES"]
  C --> E["Calculate SKIPS"]
  D --> F["Updated Channel Configuration"]
  E --> F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configure_channels.sh</strong><dd><code>Enhanced version filtering and comparison logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

utils/configure_channels.sh

<ul><li>Added <code>version_lte()</code> function to compare semantic versions<br> <li> Extract bundle minor version from bundle name for filtering<br> <li> Filter entries to only include versions in same or earlier minor <br>series<br> <li> Improved SKIPS calculation with better awk pattern to handle empty <br>results</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/fbc/pull/215/files#diff-c534808e7241fa83878860271af59b92f17e18fd45b20bdf96327f57fcf476a5">+21/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

