### PR TITLE
fix: handle skips for new entries

### DIFF
--- a/utils/configure_channels.sh
+++ b/utils/configure_channels.sh
@@ -5,72 +5,74 @@ set -euo pipefail
 #export CHANNELS="stable,stable-v1.2"
 #export GRAPH="v4.19/rhtas-operator/graph.yaml"
 
-# Returns true if version $1 <= version $2
-version_lte() {
-  [[ "$(printf '%s\n%s' "$1" "$2" | sort -V | head -1)" == "$1" ]]
+version_lt() {
+  [[ "$1" != "$2" ]] && [[ "$(printf '%s\n%s' "$1" "$2" | sort -V | head -1)" == "$1" ]]
+}
+
+get_version() {
+  echo "$1" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo ""
 }
 
 export PACKAGE_NAME=$(yq e '.entries[] | select(.schema=="olm.package") | .name' $GRAPH)
+BUNDLE_VERSION=$(get_version "$BUNDLE_NAME")
+BUNDLE_MINOR=$(echo "$BUNDLE_NAME" | grep -oE 'v[0-9]+\.[0-9]+')
+
 IFS=',' read -ra channel_list <<< "$CHANNELS"
 for channel in "${channel_list[@]}"; do
   echo "Processing channel: $channel"
   export channel
   CHANNEL_EXISTS=$(yq e '[.entries[] | select(.schema=="olm.channel" and .name==env(channel))] | (length > 0)' $GRAPH)
-  
+
   if [[ "$CHANNEL_EXISTS" == "true" ]]; then
     echo "Channel $channel exists. Updating..."
     
-    CURRENT_ENTRIES=$(yq e ".entries[] | select(.schema==\"olm.channel\" and .name==\"$channel\").entries[].name" $GRAPH || true)
-    ENTRIES_WO_BUNDLE=$(echo "$CURRENT_ENTRIES" | grep -v "^${BUNDLE_NAME}$" || true)
-    
-    if [[ -n "$ENTRIES_WO_BUNDLE" ]]; then
-      # Extract the minor version from the bundle name (e.g., "1.2" from "rhtas-operator.v1.2.1")
-      BUNDLE_MINOR=$(echo "$BUNDLE_NAME" | grep -oE 'v[0-9]+\.[0-9]+' | sed 's/^v//')
-
-      # Filter entries to only include versions in the same or earlier minor series
-      ELIGIBLE_ENTRIES=$(echo "$ENTRIES_WO_BUNDLE" | tr ' ' '\n' | while read -r entry; do
-        ENTRY_MINOR=$(echo "$entry" | grep -oE 'v[0-9]+\.[0-9]+' | sed 's/^v//')
-        if [[ -n "$ENTRY_MINOR" ]] && version_lte "$ENTRY_MINOR" "$BUNDLE_MINOR"; then
-          echo "$entry"
+    REPLACES="" REPLACES_FALLBACK="" SKIPS="" GREATER=""
+    for entry in $(yq e ".entries[] | select(.schema==\"olm.channel\" and .name==\"$channel\").entries[].name" $GRAPH); do
+      [[ "$entry" == "$BUNDLE_NAME" ]] && continue
+      ENTRY_VERSION=$(get_version "$entry")
+      [[ -z "$ENTRY_VERSION" ]] && continue
+      if version_lt "$ENTRY_VERSION" "$BUNDLE_VERSION"; then
+        ENTRY_MINOR=$(echo "$entry" | grep -oE 'v[0-9]+\.[0-9]+')
+        if [[ "$ENTRY_MINOR" == "$BUNDLE_MINOR" ]]; then
+          [[ -z "$REPLACES" || $(version_lt "$(get_version "$REPLACES")" "$ENTRY_VERSION" && echo 1) ]] && REPLACES="$entry"
+        elif [[ "$entry" == *".0" ]]; then
+          [[ -z "$REPLACES_FALLBACK" || $(version_lt "$(get_version "$REPLACES_FALLBACK")" "$ENTRY_VERSION" && echo 1) ]] && REPLACES_FALLBACK="$entry"
         fi
-      done)
+        SKIPS="${SKIPS:+$SKIPS,}$entry"
+      elif version_lt "$BUNDLE_VERSION" "$ENTRY_VERSION"; then
+        GREATER="${GREATER:+$GREATER }$entry"
+      fi
+    done
+    [[ -z "$REPLACES" ]] && REPLACES="$REPLACES_FALLBACK"
+    [[ -n "$REPLACES" ]] && SKIPS=$(echo "$SKIPS" | tr ',' '\n' | grep -v "^${REPLACES}$" | paste -sd ',' -)
 
-      export MAJOR_VERSIONS=$(echo "$ELIGIBLE_ENTRIES" | grep -E '\.0$')
-      export REPLACES=$(echo "$MAJOR_VERSIONS" | sort -V | tail -n 1)
-
-      SKIPS_ENTRIES=$(echo "$ELIGIBLE_ENTRIES" | grep -v -E '\.v1\.(0|1)\.[0-9]+')
-      export SKIPS=$(echo "$SKIPS_ENTRIES" \
-        | awk 'NF {print "\"" $0 "\""}' \
-        | paste -sd, - \
-        | sed 's/^/[/' | sed 's/$/]/'
-      )
-
-      yq -i -P eval "
-        (.entries[] | select(.schema == \"olm.channel\" and .name == \"$channel\").entries) |=
-          (map(select(.name != env(BUNDLE_NAME))) + [{
-            \"name\": env(BUNDLE_NAME),
-            \"replaces\": env(REPLACES),
-            \"skips\": (strenv(SKIPS) | fromjson)
-          }])
-      " $GRAPH
+    # Add bundle with replaces/skips
+    export REPLACES SKIPS
+    if [[ -n "$REPLACES" && -n "$SKIPS" ]]; then
+      yq -i -P eval "(.entries[] | select(.schema == \"olm.channel\" and .name == env(channel)).entries) |=
+        (map(select(.name != env(BUNDLE_NAME))) + [{\"name\": env(BUNDLE_NAME), \"replaces\": env(REPLACES), \"skips\": (env(SKIPS) | split(\",\"))}])" $GRAPH
+    elif [[ -n "$REPLACES" ]]; then
+      yq -i -P eval "(.entries[] | select(.schema == \"olm.channel\" and .name == env(channel)).entries) |=
+        (map(select(.name != env(BUNDLE_NAME))) + [{\"name\": env(BUNDLE_NAME), \"replaces\": env(REPLACES)}])" $GRAPH
     else
-      yq -i -P eval "
-        (.entries[] | select(.schema == \"olm.channel\" and .name == \"$channel\").entries) = [{
-          \"name\": env(BUNDLE_NAME)
-        }]
-      " $GRAPH
+      yq -i -P eval "(.entries[] | select(.schema == \"olm.channel\" and .name == env(channel)).entries) |=
+        (map(select(.name != env(BUNDLE_NAME))) + [{\"name\": env(BUNDLE_NAME)}])" $GRAPH
     fi
+
+    # Add bundle to skips for greater versions
+    for entry in $GREATER; do
+      export entry
+      yq -i -P eval "(.entries[] | select(.schema == \"olm.channel\" and .name == env(channel)).entries[] |
+        select(.name == env(entry)).skips) |= ((. // []) + [env(BUNDLE_NAME)] | unique)" $GRAPH
+    done
   else
-    echo "Channel $channel does not exist. Creating..."
     yq -i -P eval '
       (.entries) |= (.[0:1] + [{
-        "entries": [{
-          "name": env(BUNDLE_NAME)
-        }],
+        "entries": [{"name": env(BUNDLE_NAME)}],
         "name": env(channel),
         "package": env(PACKAGE_NAME),
         "schema": "olm.channel"
       }] + .[1:])
-  ' $GRAPH
+    ' $GRAPH
   fi
 done


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Refactor version comparison logic to handle new bundle entries correctly

- Introduce `version_lt()` function replacing `version_lte()` for stricter comparison

- Add `get_version()` helper to extract semantic versions from bundle names

- Improve skip handling by filtering entries based on version relationships

- Add bundle to skips list for entries with greater versions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Bundle Entry Processing"] --> B["Extract Version Info"]
  B --> C["Compare Versions"]
  C --> D["Categorize Entries"]
  D --> E["Set Replaces & Skips"]
  E --> F["Update Channel Entries"]
  F --> G["Add Bundle to Greater Versions"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configure_channels.sh</strong><dd><code>Refactor version handling and skip logic for entries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

utils/configure_channels.sh

<ul><li>Replaced <code>version_lte()</code> with <code>version_lt()</code> for stricter less-than <br>comparison<br> <li> Added <code>get_version()</code> function to extract semantic versions from bundle <br>names<br> <li> Refactored entry processing loop to categorize entries by version <br>relationship<br> <li> Improved skip list generation to exclude the replaces entry<br> <li> Added logic to append bundle to skips for entries with greater <br>versions<br> <li> Simplified yq commands with conditional branching for different <br>scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/fbc/pull/216/files#diff-c534808e7241fa83878860271af59b92f17e18fd45b20bdf96327f57fcf476a5">+47/-45</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

