### PR TITLE
fix: fix behaviour when removing replace from skips leaves an empty list

### DIFF
--- a/utils/configure_channels.sh
+++ b/utils/configure_channels.sh
@@ -44,7 +44,7 @@ for channel in "${channel_list[@]}"; do
       fi
     done
     [[ -z "$REPLACES" ]] && REPLACES="$REPLACES_FALLBACK"
-    [[ -n "$REPLACES" ]] && SKIPS=$(echo "$SKIPS" | tr ',' '\n' | grep -v "^${REPLACES}$" | paste -sd ',' -)
+    [[ -n "$REPLACES" ]] && SKIPS=$(echo "$SKIPS" | tr ',' '\n' | { grep -v "^${REPLACES}$" || true; } | paste -sd ',' -)
 
     # Add bundle with replaces/skips
     export REPLACES SKIPS


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix grep command failure when removing replace from skips results in empty list

- Add fallback true command to prevent pipeline exit on no matches

- Ensures SKIPS variable handles empty results gracefully


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SKIPS variable with entries"] -- "Remove REPLACES entry" --> B["grep -v filter"]
  B -- "No matches found" --> C["grep returns error"]
  C -- "Pipeline fails" --> D["Script exits"]
  E["Add || true fallback"] -- "Catches grep error" --> F["Pipeline continues"]
  F -- "Empty SKIPS handled" --> G["Script succeeds"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configure_channels.sh</strong><dd><code>Add error handling for empty grep results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

utils/configure_channels.sh

<ul><li>Modified grep command in SKIPS filtering pipeline to include <code>|| true</code> <br>fallback<br> <li> Prevents script failure when grep finds no matches after removing <br>REPLACES entry<br> <li> Allows SKIPS variable to be set to empty string without causing <br>pipeline error</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/fbc/pull/218/files#diff-c534808e7241fa83878860271af59b92f17e18fd45b20bdf96327f57fcf476a5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

