### PR TITLE
fix: use dynamic registry mirror based on fbc_dir input

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -98,8 +98,26 @@ jobs:
             export OCP_VERSION="$version"
             export GRAPH="${OCP_VERSION}/${FBC_DIR}/graph.yaml"
             export CATALOG_FILE="${OCP_VERSION}/${FBC_DIR}/catalog/${FBC_DIR}/catalog.json"
-          
+
             echo "Processing ${OCP_VERSION}..."
+
+            if [[ ! -f "$GRAPH" ]]; then
+              echo "graph.yaml not found for ${OCP_VERSION}/${FBC_DIR}. Creating seed..."
+              yq -n '
+                .entries[0].defaultChannel = "stable" |
+                .entries[0].name = env(FBC_DIR) |
+                .entries[0].schema = "olm.package" |
+                .schema = "olm.template.basic"
+              ' > "$GRAPH"
+              echo "Created seed graph.yaml for ${OCP_VERSION}/${FBC_DIR}"
+            fi
+
+            mkdir -p "$(dirname "$CATALOG_FILE")"
+            if [[ ! -f "$CATALOG_FILE" ]]; then
+              : > "$CATALOG_FILE"
+              echo "Created empty catalog.json for ${OCP_VERSION}/${FBC_DIR}"
+            fi
+
             ./utils/configure_bundles.sh
             ./utils/configure_channels.sh
             ./utils/render_catalog.sh

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -70,21 +70,21 @@ jobs:
           password: ${{ secrets.RH_REGISTRY_PASSWORD }}
 
       - name: Configure Podman Registry Mirror
+        env:
+          FBC_DIR: ${{ github.event.inputs.fbc_dir }}
         run: |
+          BUNDLE_REPO="${FBC_DIR}-bundle"
           mkdir -p ~/.config/containers
           cat <<EOF > ~/.config/containers/registries.conf
           [[registry]]
-          prefix = "registry.redhat.io/rhtas/rhtas-operator-bundle"
-          location = "registry.redhat.io/rhtas/rhtas-operator-bundle"
+          prefix = "registry.redhat.io/rhtas/${BUNDLE_REPO}"
+          location = "registry.redhat.io/rhtas/${BUNDLE_REPO}"
 
           [[registry.mirror]]
-          location = "quay.io/securesign/rhtas-operator-bundle"
-
-          [[registry.mirror]]
-          location = "quay.io/securesign/rhtas-operator-bundle-v1-3"
+          location = "quay.io/securesign/${BUNDLE_REPO}"
           EOF
 
-          echo "Registry mirror configured successfully."
+          echo "Registry mirror configured for ${BUNDLE_REPO}."
 
       - name: Process FBC Utilities
         env:


### PR DESCRIPTION
## Summary
- **Dynamic registry mirror**: The registry mirror in `create-release` workflow was hardcoded for `rhtas-operator-bundle`, causing `opm render` to fail for `policy-controller-operator` and `model-validation-operator` whose bundle images are on `quay.io` until the product is released on `registry.redhat.io`. Now derives `BUNDLE_REPO` from the `fbc_dir` workflow input so the mirror works for any operator.
- **Bootstrap missing files for new OCP versions**: When an operator (e.g. `policy-controller-operator` on `v4.22`) doesn't have `graph.yaml` or `catalog.json`, the utility scripts fail. Now auto-creates a minimal seed `graph.yaml` (with just the `olm.package` entry) and an empty `catalog.json` so the scripts can proceed normally.
- Removes the stale `rhtas-operator-bundle-v1-3` mirror entry.

## Test plan
- [x] Tested locally: ran bootstrap + all three scripts for `policy-controller-operator` on `v4.22` (missing both `graph.yaml` and `catalog/`) — all passed, correct catalog rendered
- [ ] Run `create-release` workflow with `fbc_dir=policy-controller-operator` on a version missing `graph.yaml`
- [ ] Run `create-release` workflow with `fbc_dir=rhtas-operator` and verify it still works
- [ ] Run `create-release` workflow with `fbc_dir=model-validation-operator` and verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)