### PR TITLE
feat: automate adding a new OCP version to FBC

### DIFF
--- a/.github/workflows/add-ocp-version.yaml
+++ b/.github/workflows/add-ocp-version.yaml
@@ -1,0 +1,90 @@
+name: Add new OCP version
+
+# Bootstraps a brand-new, EMPTY OCP version across both repos:
+#  - securesign/fbc:       per-operator skeleton + .tekton PipelineRuns + cron matrix entry
+#  - securesign/pipelines: Konflux component onboarding (CaC)
+# main mirrors the published Red Hat catalog, so the new version starts empty; the
+# nightly "Update OCP Catalogs" cron populates it once the operators ship upstream.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ocp_version:
+        description: 'New OCP version to add (e.g. v4.23 or v5.0)'
+        required: true
+      source_version:
+        description: 'Version to template from (optional; defaults to the highest existing)'
+        required: false
+        default: ''
+
+jobs:
+  add-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token (fbc + pipelines)
+        id: token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PR_MANAGER_APP_ID }}
+          private-key: ${{ secrets.PR_MANAGER_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            fbc
+            pipelines
+
+      # ---- fbc side ----
+      - name: Checkout fbc
+        uses: actions/checkout@v4
+        with:
+          path: fbc
+          token: ${{ steps.token.outputs.token }}
+
+      - name: Install OPM
+        uses: ./fbc/.github/actions/install-opm
+
+      - name: Generate fbc skeleton
+        working-directory: fbc
+        run: ./utils/new_ocp_version.sh "${{ inputs.ocp_version }}" ${{ inputs.source_version }}
+
+      - name: Open fbc PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ steps.token.outputs.token }}
+          path: fbc
+          branch: add-ocp-${{ inputs.ocp_version }}
+          base: main
+          commit-message: "chore: add OCP ${{ inputs.ocp_version }} FBC skeleton"
+          title: "chore: add OCP ${{ inputs.ocp_version }} FBC skeleton"
+          body: |
+            Automated empty FBC skeleton for **${{ inputs.ocp_version }}**
+            (per-operator dirs, `.tekton` PipelineRuns, cron matrix entry).
+            The catalog is intentionally empty until the operators ship upstream.
+
+            Companion CaC PR onboards the Konflux components in `securesign/pipelines`.
+
+      # ---- pipelines (CaC) side ----
+      - name: Checkout pipelines
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository_owner }}/pipelines
+          path: pipelines
+          token: ${{ steps.token.outputs.token }}
+
+      - name: Generate CaC onboarding
+        run: ./fbc/utils/new_cac_version.sh pipelines "${{ inputs.ocp_version }}" ${{ inputs.source_version }}
+
+      - name: Open pipelines PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ steps.token.outputs.token }}
+          path: pipelines
+          branch: add-ocp-${{ inputs.ocp_version }}
+          base: main
+          commit-message: "chore: onboard OCP ${{ inputs.ocp_version }} FBC components"
+          title: "chore: onboard OCP ${{ inputs.ocp_version }} FBC components"
+          body: |
+            Automated Konflux onboarding for **${{ inputs.ocp_version }}** FBC components
+            (Component + IntegrationTestScenarios + ImageRepository, wired into the overlays).
+
+            Merge this **before** the companion `securesign/fbc` PR so the build
+            service accounts exist when the Tekton PipelineRuns first fire.

--- a/utils/new_cac_version.sh
+++ b/utils/new_cac_version.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Onboard a new OCP version's FBC components into the securesign/pipelines (CaC) repo.
+#
+# For each operator (rhtas, pco, mvo) this copies the latest ocp/<op>/vX.Y kustomize
+# component to the new version (rewriting the version tokens) and wires the new
+# component into that operator's overlay kustomization.
+#
+# Usage: utils/new_cac_version.sh <pipelines-repo-dir> <new-version> [source-version]
+#   <pipelines-repo-dir>  path to a securesign/pipelines checkout
+#   <new-version>         version to create,   e.g. v4.23
+#   [source-version]      version to copy from (default: latest per operator)
+
+set -euo pipefail
+
+readonly OPERATORS=(rhtas pco mvo)
+
+die() {
+    echo "error: $*" >&2
+    exit 1
+}
+
+assert_valid_version() {
+    local version="$1"
+    [[ "$version" =~ ^v[0-9]+\.[0-9]+$ ]] \
+        || die "invalid version '$version' (expected vMAJOR.MINOR, e.g. v4.23)"
+}
+
+# Highest existing vX.Y directory under the given operator dir.
+latest_version_in() {
+    local dir="$1"
+    ( cd "$dir" && ls -d v[0-9]*.[0-9]*/ 2>/dev/null | tr -d '/' | sort -V | tail -n1 )
+}
+
+# Rewrite version tokens on stdin -> stdout. A version appears three ways and all
+# must change: dash (v4-22, resource names), dotted (v4.22, git context path) and
+# bare (4.22, comments). Dots are escaped so sed matches them literally.
+rewrite_version_tokens() {
+    local source_version="$1" new_version="$2"
+    local source_dash="${source_version//./-}"    new_dash="${new_version//./-}"
+    local source_bare="${source_version#v}"       new_bare="${new_version#v}"
+    local source_dotted_re="${source_version//./\\.}"
+    local source_bare_re="${source_bare//./\\.}"
+
+    sed -e "s/${source_dash}/${new_dash}/g" \
+        -e "s/${source_dotted_re}/${new_version}/g" \
+        -e "s/${source_bare_re}/${new_bare}/g"
+}
+
+# Add the new component to the operator's overlay kustomization (idempotent).
+wire_into_overlay() {
+    local operator="$1" overlay_base="$2" new_version="$3"
+    local kustomization="$overlay_base/$operator-fbc/kustomization.yaml"
+    local component_ref="../../base/ocp/$operator/$new_version"
+
+    if yq e '.components[]' "$kustomization" | grep -qx "$component_ref"; then
+        echo "    already wired into $operator-fbc"
+        return
+    fi
+    yq e -i ".components += [\"$component_ref\"]" "$kustomization"
+    echo "    wired into $operator-fbc"
+}
+
+# Copy one operator's component dir to the new version and wire it into the overlay.
+onboard_operator() {
+    local operator="$1" ocp_base="$2" overlay_base="$3" new_version="$4" source_override="$5"
+    local operator_dir="$ocp_base/$operator"
+
+    if [[ ! -d "$operator_dir" ]]; then
+        echo "  skip $operator (no $operator_dir)"
+        return
+    fi
+
+    local source_version
+    source_version="${source_override:-$(latest_version_in "$operator_dir")}"
+    [[ -n "$source_version" && -d "$operator_dir/$source_version" ]] \
+        || die "no source version for $operator"
+
+    local dst_dir="$operator_dir/$new_version"
+    [[ ! -d "$dst_dir" ]] || die "$operator/$new_version already exists"
+    echo "  $operator: $source_version -> $new_version"
+
+    mkdir -p "$dst_dir"
+    # kustomization.yaml is version-agnostic; patch.yaml needs its tokens rewritten.
+    cp "$operator_dir/$source_version/kustomization.yaml" "$dst_dir/kustomization.yaml"
+    rewrite_version_tokens "$source_version" "$new_version" \
+        < "$operator_dir/$source_version/patch.yaml" > "$dst_dir/patch.yaml"
+
+    wire_into_overlay "$operator" "$overlay_base" "$new_version"
+}
+
+main() {
+    local pipelines_dir="${1:-}" new_version="${2:-}" source_override="${3:-}"
+    [[ -n "$pipelines_dir" && -n "$new_version" ]] \
+        || die "usage: $0 <pipelines-repo-dir> <new-version> [source-version]"
+    assert_valid_version "$new_version"
+
+    local ocp_base="$pipelines_dir/konflux-configs/base/project/base/ocp"
+    local overlay_base="$pipelines_dir/konflux-configs/base/project/overlay"
+    [[ -d "$ocp_base" && -d "$overlay_base" ]] \
+        || die "not a pipelines CaC checkout: $pipelines_dir"
+
+    local operator
+    for operator in "${OPERATORS[@]}"; do
+        onboard_operator "$operator" "$ocp_base" "$overlay_base" "$new_version" "$source_override"
+    done
+
+    echo "Done. Review the generated CaC files for $new_version."
+}
+
+main "$@"

--- a/utils/new_ocp_version.sh
+++ b/utils/new_ocp_version.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+#
+# Generate an empty FBC skeleton for a new OCP version (e.g. v4.23 or v5.0).
+#
+# For each operator this creates the per-operator directory tree with a minimal
+# graph.yaml / catalog.json / catalog.Dockerfile / devfile.yaml / license, copies
+# the three .tekton push PipelineRuns, and adds the version to the sync-catalog
+# cron matrix.
+#
+# `main` mirrors the *published* Red Hat catalog, so a brand-new version starts
+# EMPTY (no package entries). The nightly cron populates it once the operators
+# ship upstream.
+#
+# Usage: utils/new_ocp_version.sh <new-version> [source-version]
+#   <new-version>     version to create,   e.g. v4.23 or v5.0
+#   [source-version]  version to copy from (default: highest existing vX.Y dir)
+
+set -euo pipefail
+
+readonly OPERATORS=(rhtas-operator policy-controller-operator model-validation-operator)
+readonly SYNC_WORKFLOW=".github/workflows/sync-catalog.yaml"
+
+die() {
+    echo "error: $*" >&2
+    exit 1
+}
+
+# vX.Y -> vX-Y  (form used in .tekton file names and resource names).
+version_to_dash() {
+    local version="$1"
+    echo "${version//./-}"
+}
+
+# vX.Y -> X  (major number, used to pick the openshiftN image group).
+version_major() {
+    local version="$1"
+    version="${version#v}"
+    echo "${version%%.*}"
+}
+
+assert_valid_version() {
+    local version="$1"
+    [[ "$version" =~ ^v[0-9]+\.[0-9]+$ ]] \
+        || die "invalid version '$version' (expected vMAJOR.MINOR, e.g. v4.23)"
+}
+
+# Highest existing vX.Y directory in the repo root (default source version).
+latest_existing_version() {
+    ls -d v[0-9]*.[0-9]*/ 2>/dev/null | tr -d '/' | sort -V | tail -n1
+}
+
+# .tekton file-name prefix for an operator.
+tekton_prefix() {
+    case "$1" in
+        rhtas-operator)             echo "rhtas" ;;
+        policy-controller-operator) echo "pco" ;;
+        model-validation-operator)  echo "mvo" ;;
+        *) die "unknown operator '$1'" ;;
+    esac
+}
+
+# catalog.Dockerfile FROM line. Red Hat moves the image group from openshift4 to
+# openshift5 at v5.0, so the group must track the major version.
+dockerfile_from_line() {
+    local version="$1"
+    echo "FROM registry.redhat.io/openshift$(version_major "$version")/ose-operator-registry-rhel9:${version}"
+}
+
+# Create one operator's empty FBC skeleton: <source-version> -> <new-version>.
+create_operator_skeleton() {
+    local operator="$1" source_version="$2" new_version="$3"
+    local src="${source_version}/${operator}"
+    local dst="${new_version}/${operator}"
+
+    if [[ ! -d "$src" ]]; then
+        echo "  skip $operator (not present in $source_version)"
+        return
+    fi
+    echo "  operator: $operator"
+
+    mkdir -p "$dst/catalog/$operator" "$dst/licenses" "$dst/$new_version"
+    : > "$dst/$new_version/.empty"   # keep the otherwise-empty dir tracked by git
+
+    # Empty graph on purpose: no package until the operator ships. A package with
+    # no bundle fails `opm serve --cache-only` at build time.
+    yq -n '.schema = "olm.template.basic" | .entries = []' > "$dst/graph.yaml"
+
+    # Copy the Dockerfile, rewriting only the FROM line so the image group matches
+    # the new major version.
+    sed -E "s|^FROM registry.redhat.io/openshift[0-9]+/ose-operator-registry-rhel9:.*|$(dockerfile_from_line "$new_version")|" \
+        "$src/catalog.Dockerfile" > "$dst/catalog.Dockerfile"
+
+    # devfile differs only by the version string.
+    sed "s/${source_version}/${new_version}/g" "$src/devfile.yaml" > "$dst/devfile.yaml"
+
+    cp "$src/licenses/license.txt" "$dst/licenses/license.txt"
+
+    # Render catalog.json from the empty graph (render_catalog.sh reads the target
+    # file first, so create it empty).
+    local catalog_file="$dst/catalog/$operator/catalog.json"
+    : > "$catalog_file"
+    OCP_VERSION="$new_version" FBC_DIR="$operator" CATALOG_FILE="$catalog_file" \
+        ./utils/render_catalog.sh
+}
+
+# Copy an operator's .tekton push PipelineRun to the new version.
+copy_tekton_pipelinerun() {
+    local operator="$1" source_version="$2" new_version="$3"
+    local prefix source_dash new_dash src dst
+    prefix="$(tekton_prefix "$operator")"
+    source_dash="$(version_to_dash "$source_version")"
+    new_dash="$(version_to_dash "$new_version")"
+    src=".tekton/${prefix}-fbc-${source_dash}-push.yaml"
+    dst=".tekton/${prefix}-fbc-${new_dash}-push.yaml"
+
+    if [[ ! -f "$src" ]]; then
+        echo "  skip .tekton for $operator (no $src)"
+        return
+    fi
+    sed -e "s/${source_dash}/${new_dash}/g" -e "s/${source_version}/${new_version}/g" \
+        "$src" > "$dst"
+    echo "  tekton: $dst"
+}
+
+# Add the new version to the nightly sync-catalog cron matrix (idempotent).
+add_to_cron_matrix() {
+    local new_version="$1"
+    local path='.jobs.update-catalogs.strategy.matrix.ocp_version'
+
+    if yq e "${path}[]" "$SYNC_WORKFLOW" | grep -qx "$new_version"; then
+        echo "  cron matrix already lists $new_version"
+        return
+    fi
+    yq e -i "${path} += [\"$new_version\"]" "$SYNC_WORKFLOW"
+    echo "  added $new_version to $SYNC_WORKFLOW"
+}
+
+main() {
+    local new_version="${1:-}" source_version="${2:-}"
+    [[ -n "$new_version" ]] || die "usage: $0 <new-version> [source-version]"
+    assert_valid_version "$new_version"
+
+    # Run from the repo root (this script lives in utils/).
+    cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+    [[ ! -d "$new_version" ]] || die "version $new_version already exists"
+
+    source_version="${source_version:-$(latest_existing_version)}"
+    [[ -n "$source_version" && -d "$source_version" ]] \
+        || die "source version not found: '${source_version:-<none>}'"
+    assert_valid_version "$source_version"
+
+    echo "Creating $new_version (from $source_version)"
+
+    local operator
+    for operator in "${OPERATORS[@]}"; do
+        create_operator_skeleton "$operator" "$source_version" "$new_version"
+    done
+    for operator in "${OPERATORS[@]}"; do
+        copy_tekton_pipelinerun "$operator" "$source_version" "$new_version"
+    done
+    add_to_cron_matrix "$new_version"
+
+    echo "Done. Review the generated files for $new_version."
+}
+
+main "$@"

--- a/utils/render_catalog.sh
+++ b/utils/render_catalog.sh
@@ -5,7 +5,9 @@ set -euo pipefail
 #FBC_DIR="rhtas-operator"
 #CATALOG_FILE="v4.19/${FBC_DIR}/catalog/rhtas-operator/catalog.json"
 
-minor=${OCP_VERSION#v4.}
+ver=${OCP_VERSION#v}
+major=${ver%%.*}
+minor=${ver#*.}
 minor=${minor%%.*}
 
 # Anything related to related_images can be removed once we deprecate 1.1.x
@@ -25,7 +27,7 @@ reduce .[] as $item ({};
 )' "$CATALOG_FILE")
 
 migrate_flag=""
-if (( minor >= 17 )); then
+if (( major > 4 || (major == 4 && minor >= 17) )); then
     migrate_flag="--migrate-level=bundle-object-to-csv-metadata"
 fi
 


### PR DESCRIPTION
## What

Automates adding a new OCP version (e.g. `v4.23`, `v5.0`) to the FBC catalog, which is manual and error-prone today.

- `utils/new_ocp_version.sh <new-version> [source-version]` — generates the empty per-operator skeleton (graph.yaml, catalog.json, catalog.Dockerfile, devfile.yaml, license), copies the three `.tekton` push PipelineRuns, and adds the version to the sync-catalog cron matrix.
- `utils/new_cac_version.sh <pipelines-dir> <new-version> [source-version]` — onboards the matching Konflux components in `securesign/pipelines` (copies each operator's kustomize component, rewrites version tokens, wires the overlay).
- `.github/workflows/add-ocp-version.yaml` — `workflow_dispatch` that runs both and opens a PR in each repo via the PR_MANAGER GitHub App.
- `utils/render_catalog.sh` — parse major/minor so the migrate flag and image group are correct for v5.x (was hard-wired to `v4.`).

`main` mirrors the published Red Hat catalog, so a new version starts **empty**; the nightly cron populates it once the operators ship upstream.

## Testing

- `new_ocp_version.sh v4.23` and `v5.0 v4.22`: full trees for all 3 operators, `opm validate` passes, `opm serve --cache-only` builds the cache; FROM correctly `openshift4:v4.23` / `openshift5:v5.0`.
- Fail-fast guards verified (existing version, invalid format).
- `new_cac_version.sh ../pipelines v4.23`: all 3 operators onboarded, all token forms rewritten, Go-template vars untouched, `kustomize build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)